### PR TITLE
Feature/example met processing

### DIFF
--- a/examples/004-process_met_data.ipynb
+++ b/examples/004-process_met_data.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mmctools.dataloaders import read_dir # for reading a series of data files\n",
+    "from mmctools.dataloaders import read_dir, read_files # for reading a series of data files\n",
     "from mmctools.measurements import metmast # provides readers for metmast data"
    ]
   },
@@ -57,8 +57,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Data downloaded from the DAP\n",
-    "datadir = '/Users/equon/WFIP2/PS07/201611'"
+    "dataset = 'wfip2/met.z07.b0'\n",
+    "datadir = 'data'  # where to download files from the DAP"
    ]
   },
   {
@@ -75,12 +75,80 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Data I/O"
+    "## Download data from DAP on the fly"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No authentication found. Using guest credentials...\n",
+      "username: quon\n",
+      "password: ········\n",
+      "Success!\n",
+      "12 data files selected\n",
+      "Download successful! data/wfip2.met.z07.b0/met.z07.b0.20161121.180000.txt\n",
+      "Download successful! data/wfip2.met.z07.b0/met.z07.b0.20161121.210000.txt\n",
+      "Download successful! data/wfip2.met.z07.b0/met.z07.b0.20161121.200000.txt\n",
+      "Download successful! data/wfip2.met.z07.b0/met.z07.b0.20161121.170000.txt\n",
+      "Download successful! data/wfip2.met.z07.b0/met.z07.b0.20161121.190000.txt\n",
+      "Download successful! data/wfip2.met.z07.b0/met.z07.b0.20161121.220000.txt\n",
+      "Download successful! data/wfip2.met.z07.b0/met.z07.b0.20161121.230000.txt\n",
+      "Download successful! data/wfip2.met.z07.b0/met.z07.b0.20161122.000000.txt\n",
+      "Download successful! data/wfip2.met.z07.b0/met.z07.b0.20161122.020000.txt\n",
+      "Download successful! data/wfip2.met.z07.b0/met.z07.b0.20161122.030000.txt\n",
+      "Download successful! data/wfip2.met.z07.b0/met.z07.b0.20161122.040000.txt\n",
+      "Download successful! data/wfip2.met.z07.b0/met.z07.b0.20161122.010000.txt\n",
+      "Files to process:\n",
+      "  data/wfip2.met.z07.b0/met.z07.b0.20161121.170000.txt\n",
+      "  data/wfip2.met.z07.b0/met.z07.b0.20161121.180000.txt\n",
+      "  data/wfip2.met.z07.b0/met.z07.b0.20161121.190000.txt\n",
+      "  data/wfip2.met.z07.b0/met.z07.b0.20161121.200000.txt\n",
+      "  data/wfip2.met.z07.b0/met.z07.b0.20161121.210000.txt \n",
+      "  ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    import A2e\n",
+    "except ImportError:\n",
+    "    print('dap-py package not available; need to manually download files')\n",
+    "else:\n",
+    "    a2e = A2e.A2e()\n",
+    "    a2e.setup_cert_auth()\n",
+    "    filter_arg = {\n",
+    "        'Dataset': dataset,\n",
+    "        'date_time': {\n",
+    "            'between': [starttime.strftime('%Y%m%d%H%M%S'), endtime.strftime('%Y%m%d%H%M%S')]\n",
+    "        },\n",
+    "        'file_type':'txt',\n",
+    "    }\n",
+    "    datafiles = a2e.search(filter_arg)\n",
+    "    print(len(datafiles),'data files selected')\n",
+    "    filelist = a2e.download_files(datafiles, path=datadir)\n",
+    "    if filelist is None:\n",
+    "        print('No files were downloaded; need to manually download files to '+datapath)\n",
+    "    else:\n",
+    "        filelist.sort()\n",
+    "        print('Files to process:\\n ','\\n  '.join(filelist[:5]),'\\n  ...')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data I/O"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -102,7 +170,7 @@
        "             ('p10X', 1)])"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -127,21 +195,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = read_dir(datadir,\n",
-    "              file_filter='*.2016112[12].*.txt', # read 20161121 and 20161122 only\n",
-    "              reader=metmast.read_data, column_spec=metmast.RMYoung_05106,\n",
-    "              height=3.0, # measurement height\n",
-    "              datetime_offset=-60, # shift 60s to line up with begining of interval\n",
-    "              start=starttime, end=endtime)"
+    "# df = read_dir(datadir,\n",
+    "#               file_filter='*.2016112[12].*.txt', # read 20161121 and 20161122 only\n",
+    "#               reader=metmast.read_data, column_spec=metmast.RMYoung_05106,\n",
+    "#               height=3.0, # measurement height\n",
+    "#               datetime_offset=-60, # shift 60s to line up with begining of interval\n",
+    "#               start=starttime, end=endtime)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = read_files(filelist,\n",
+    "                reader=metmast.read_data, column_spec=metmast.RMYoung_05106,\n",
+    "                height=3.0, # measurement height\n",
+    "                datetime_offset=-60, # shift 60s to line up with begining of interval\n",
+    "                start=starttime, end=endtime)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -285,7 +366,7 @@
        "2016-11-21 17:04:00 3.0     83.5  959.51    268.8  6.907  13.69  "
       ]
      },
-     "execution_count": 9,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -305,7 +386,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -449,7 +530,7 @@
        "2016-11-21 17:04:00 3.0     83.5  959.51    268.8  6.907  13.69  "
       ]
      },
-     "execution_count": 10,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -461,7 +542,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -471,7 +552,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -491,7 +572,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -748,7 +829,7 @@
        "2016-11-22 04:00:00  12.770000  "
       ]
      },
-     "execution_count": 13,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -760,7 +841,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -772,7 +853,7 @@
        "Name: 2016-11-21 23:00:00, dtype: float64"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -784,7 +865,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -801,7 +882,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -810,7 +891,7 @@
        "10.97058660841359"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -821,7 +902,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -830,7 +911,7 @@
        "10.961379766199544"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -849,7 +930,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -858,7 +939,7 @@
        "276.872367630902"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -877,7 +958,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -886,7 +967,7 @@
        "0.007180266769687286"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -897,7 +978,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -906,7 +987,7 @@
        "0.007098324862722254"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -926,7 +1007,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -935,7 +1016,7 @@
        "282.36317505413456"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -946,7 +1027,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -955,7 +1036,7 @@
        "282.3604000240343"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/examples/004-process_met_data.ipynb
+++ b/examples/004-process_met_data.ipynb
@@ -1,0 +1,997 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mmctools.dataloaders import read_dir # for reading a series of data files\n",
+    "from mmctools.measurements import metmast # provides readers for metmast data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mmctools.helper_functions import e_s, T_d, w_s, T_to_Tv\n",
+    "from mmctools.helper_functions import epsilon as eps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Process met mast data, calculate relevant atmospheric quantities\n",
+    "\n",
+    "sample data from WFIP2 Physics Site PS07 met station (https://a2e.energy.gov/data/wfip2/met.z07.b0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Data downloaded from the DAP\n",
+    "datadir = '/Users/equon/WFIP2/PS07/201611'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "starttime = pd.to_datetime('2016-11-21 17:00')\n",
+    "endtime = pd.to_datetime('2016-11-22 04:00')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data I/O"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OrderedDict([('ID', None),\n",
+       "             ('year', '%Y'),\n",
+       "             ('day', '%j'),\n",
+       "             ('time', '%H%M'),\n",
+       "             ('HorizontalWind', 1),\n",
+       "             ('wspd', 1),\n",
+       "             ('wdir', 1),\n",
+       "             ('wdir_std', 1),\n",
+       "             ('T', <function mmctools.measurements.metmast.<lambda>(Ta)>),\n",
+       "             ('RH', 1),\n",
+       "             ('P', 1),\n",
+       "             ('SW_down', 1),\n",
+       "             ('T10X', 1),\n",
+       "             ('p10X', 1)])"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# sensor data format\n",
+    "metmast.RMYoung_05106"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Basic usage (with generic CSV reader):\n",
+    "\n",
+    "`df = read_dir(datadir)`\n",
+    "\n",
+    "Met data usage:\n",
+    "\n",
+    "`df = read_dir(datadir, reader=metmast.read_data, column_spec=metmast.RMYoung_05106)`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = read_dir(datadir,\n",
+    "              file_filter='*.2016112[12].*.txt', # read 20161121 and 20161122 only\n",
+    "              reader=metmast.read_data, column_spec=metmast.RMYoung_05106,\n",
+    "              height=3.0, # measurement height\n",
+    "              datetime_offset=-60, # shift 60s to line up with begining of interval\n",
+    "              start=starttime, end=endtime)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>HorizontalWind</th>\n",
+       "      <th>wspd</th>\n",
+       "      <th>wdir</th>\n",
+       "      <th>wdir_std</th>\n",
+       "      <th>T</th>\n",
+       "      <th>RH</th>\n",
+       "      <th>P</th>\n",
+       "      <th>SW_down</th>\n",
+       "      <th>T10X</th>\n",
+       "      <th>p10X</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>datetime</th>\n",
+       "      <th>height</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 17:00:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>0.871</td>\n",
+       "      <td>0.858</td>\n",
+       "      <td>271.5</td>\n",
+       "      <td>9.780</td>\n",
+       "      <td>279.481</td>\n",
+       "      <td>84.2</td>\n",
+       "      <td>959.58</td>\n",
+       "      <td>255.8</td>\n",
+       "      <td>6.605</td>\n",
+       "      <td>14.17</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 17:01:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>1.076</td>\n",
+       "      <td>1.074</td>\n",
+       "      <td>264.6</td>\n",
+       "      <td>3.722</td>\n",
+       "      <td>279.509</td>\n",
+       "      <td>83.2</td>\n",
+       "      <td>959.51</td>\n",
+       "      <td>263.0</td>\n",
+       "      <td>6.665</td>\n",
+       "      <td>13.58</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 17:02:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>1.204</td>\n",
+       "      <td>1.192</td>\n",
+       "      <td>260.4</td>\n",
+       "      <td>7.930</td>\n",
+       "      <td>279.552</td>\n",
+       "      <td>83.0</td>\n",
+       "      <td>959.51</td>\n",
+       "      <td>264.6</td>\n",
+       "      <td>6.732</td>\n",
+       "      <td>13.37</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 17:03:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>1.093</td>\n",
+       "      <td>1.081</td>\n",
+       "      <td>274.8</td>\n",
+       "      <td>8.350</td>\n",
+       "      <td>279.622</td>\n",
+       "      <td>83.3</td>\n",
+       "      <td>959.56</td>\n",
+       "      <td>257.6</td>\n",
+       "      <td>6.839</td>\n",
+       "      <td>13.73</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 17:04:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>1.552</td>\n",
+       "      <td>1.545</td>\n",
+       "      <td>260.3</td>\n",
+       "      <td>5.421</td>\n",
+       "      <td>279.703</td>\n",
+       "      <td>83.5</td>\n",
+       "      <td>959.51</td>\n",
+       "      <td>268.8</td>\n",
+       "      <td>6.907</td>\n",
+       "      <td>13.69</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                            HorizontalWind   wspd   wdir  wdir_std        T  \\\n",
+       "datetime            height                                                    \n",
+       "2016-11-21 17:00:00 3.0              0.871  0.858  271.5     9.780  279.481   \n",
+       "2016-11-21 17:01:00 3.0              1.076  1.074  264.6     3.722  279.509   \n",
+       "2016-11-21 17:02:00 3.0              1.204  1.192  260.4     7.930  279.552   \n",
+       "2016-11-21 17:03:00 3.0              1.093  1.081  274.8     8.350  279.622   \n",
+       "2016-11-21 17:04:00 3.0              1.552  1.545  260.3     5.421  279.703   \n",
+       "\n",
+       "                              RH       P  SW_down   T10X   p10X  \n",
+       "datetime            height                                       \n",
+       "2016-11-21 17:00:00 3.0     84.2  959.58    255.8  6.605  14.17  \n",
+       "2016-11-21 17:01:00 3.0     83.2  959.51    263.0  6.665  13.58  \n",
+       "2016-11-21 17:02:00 3.0     83.0  959.51    264.6  6.732  13.37  \n",
+       "2016-11-21 17:03:00 3.0     83.3  959.56    257.6  6.839  13.73  \n",
+       "2016-11-21 17:04:00 3.0     83.5  959.51    268.8  6.907  13.69  "
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "At this point, units and column names have been standardized according to the sensor data format specification.\n",
+    "\n",
+    "Call `metmast.standard_output()` to reorder columns and (optionally) write output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>wspd</th>\n",
+       "      <th>wdir</th>\n",
+       "      <th>HorizontalWind</th>\n",
+       "      <th>wdir_std</th>\n",
+       "      <th>T</th>\n",
+       "      <th>RH</th>\n",
+       "      <th>P</th>\n",
+       "      <th>SW_down</th>\n",
+       "      <th>T10X</th>\n",
+       "      <th>p10X</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>datetime</th>\n",
+       "      <th>height</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 17:00:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>0.858</td>\n",
+       "      <td>271.5</td>\n",
+       "      <td>0.871</td>\n",
+       "      <td>9.780</td>\n",
+       "      <td>279.481</td>\n",
+       "      <td>84.2</td>\n",
+       "      <td>959.58</td>\n",
+       "      <td>255.8</td>\n",
+       "      <td>6.605</td>\n",
+       "      <td>14.17</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 17:01:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>1.074</td>\n",
+       "      <td>264.6</td>\n",
+       "      <td>1.076</td>\n",
+       "      <td>3.722</td>\n",
+       "      <td>279.509</td>\n",
+       "      <td>83.2</td>\n",
+       "      <td>959.51</td>\n",
+       "      <td>263.0</td>\n",
+       "      <td>6.665</td>\n",
+       "      <td>13.58</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 17:02:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>1.192</td>\n",
+       "      <td>260.4</td>\n",
+       "      <td>1.204</td>\n",
+       "      <td>7.930</td>\n",
+       "      <td>279.552</td>\n",
+       "      <td>83.0</td>\n",
+       "      <td>959.51</td>\n",
+       "      <td>264.6</td>\n",
+       "      <td>6.732</td>\n",
+       "      <td>13.37</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 17:03:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>1.081</td>\n",
+       "      <td>274.8</td>\n",
+       "      <td>1.093</td>\n",
+       "      <td>8.350</td>\n",
+       "      <td>279.622</td>\n",
+       "      <td>83.3</td>\n",
+       "      <td>959.56</td>\n",
+       "      <td>257.6</td>\n",
+       "      <td>6.839</td>\n",
+       "      <td>13.73</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 17:04:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>1.545</td>\n",
+       "      <td>260.3</td>\n",
+       "      <td>1.552</td>\n",
+       "      <td>5.421</td>\n",
+       "      <td>279.703</td>\n",
+       "      <td>83.5</td>\n",
+       "      <td>959.51</td>\n",
+       "      <td>268.8</td>\n",
+       "      <td>6.907</td>\n",
+       "      <td>13.69</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                             wspd   wdir  HorizontalWind  wdir_std        T  \\\n",
+       "datetime            height                                                    \n",
+       "2016-11-21 17:00:00 3.0     0.858  271.5           0.871     9.780  279.481   \n",
+       "2016-11-21 17:01:00 3.0     1.074  264.6           1.076     3.722  279.509   \n",
+       "2016-11-21 17:02:00 3.0     1.192  260.4           1.204     7.930  279.552   \n",
+       "2016-11-21 17:03:00 3.0     1.081  274.8           1.093     8.350  279.622   \n",
+       "2016-11-21 17:04:00 3.0     1.545  260.3           1.552     5.421  279.703   \n",
+       "\n",
+       "                              RH       P  SW_down   T10X   p10X  \n",
+       "datetime            height                                       \n",
+       "2016-11-21 17:00:00 3.0     84.2  959.58    255.8  6.605  14.17  \n",
+       "2016-11-21 17:01:00 3.0     83.2  959.51    263.0  6.665  13.58  \n",
+       "2016-11-21 17:02:00 3.0     83.0  959.51    264.6  6.732  13.37  \n",
+       "2016-11-21 17:03:00 3.0     83.3  959.56    257.6  6.839  13.73  \n",
+       "2016-11-21 17:04:00 3.0     83.5  959.51    268.8  6.907  13.69  "
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ps7 = metmast.standard_output(df)\n",
+    "ps7.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# write out standardized timeseries data in csv format\n",
+    "metmast.standard_output(df,'test.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# write out standardized timeseries data in netcdf format\n",
+    "metmast.standard_output(df,'test.nc')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Temperature/pressure conversions\n",
+    "As an example, pick an arbitrary set of hourly mean values.\n",
+    "\n",
+    "The different calculation methods shown below should produce similar results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>wspd</th>\n",
+       "      <th>wdir</th>\n",
+       "      <th>HorizontalWind</th>\n",
+       "      <th>wdir_std</th>\n",
+       "      <th>T</th>\n",
+       "      <th>RH</th>\n",
+       "      <th>P</th>\n",
+       "      <th>SW_down</th>\n",
+       "      <th>T10X</th>\n",
+       "      <th>p10X</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>datetime</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 17:00:00</th>\n",
+       "      <td>1.944483</td>\n",
+       "      <td>240.593333</td>\n",
+       "      <td>1.958867</td>\n",
+       "      <td>6.601150</td>\n",
+       "      <td>280.433667</td>\n",
+       "      <td>80.503333</td>\n",
+       "      <td>959.679833</td>\n",
+       "      <td>292.691667</td>\n",
+       "      <td>8.233717</td>\n",
+       "      <td>13.519167</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 18:00:00</th>\n",
+       "      <td>2.844367</td>\n",
+       "      <td>251.378333</td>\n",
+       "      <td>2.864533</td>\n",
+       "      <td>6.527967</td>\n",
+       "      <td>280.612000</td>\n",
+       "      <td>83.845000</td>\n",
+       "      <td>960.026000</td>\n",
+       "      <td>235.665000</td>\n",
+       "      <td>9.661167</td>\n",
+       "      <td>13.455833</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 19:00:00</th>\n",
+       "      <td>4.265933</td>\n",
+       "      <td>251.836667</td>\n",
+       "      <td>4.302117</td>\n",
+       "      <td>7.274217</td>\n",
+       "      <td>282.391000</td>\n",
+       "      <td>78.631667</td>\n",
+       "      <td>960.055167</td>\n",
+       "      <td>382.946667</td>\n",
+       "      <td>10.185167</td>\n",
+       "      <td>13.479667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 20:00:00</th>\n",
+       "      <td>5.820167</td>\n",
+       "      <td>255.511667</td>\n",
+       "      <td>5.859383</td>\n",
+       "      <td>6.527083</td>\n",
+       "      <td>282.636833</td>\n",
+       "      <td>77.340000</td>\n",
+       "      <td>960.099833</td>\n",
+       "      <td>342.491667</td>\n",
+       "      <td>11.307333</td>\n",
+       "      <td>13.521000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 21:00:00</th>\n",
+       "      <td>6.272000</td>\n",
+       "      <td>251.678333</td>\n",
+       "      <td>6.310000</td>\n",
+       "      <td>6.242950</td>\n",
+       "      <td>282.516333</td>\n",
+       "      <td>75.923333</td>\n",
+       "      <td>960.322667</td>\n",
+       "      <td>242.920500</td>\n",
+       "      <td>11.641833</td>\n",
+       "      <td>13.466667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 22:00:00</th>\n",
+       "      <td>6.104433</td>\n",
+       "      <td>254.995000</td>\n",
+       "      <td>6.141233</td>\n",
+       "      <td>6.223867</td>\n",
+       "      <td>282.975000</td>\n",
+       "      <td>70.868333</td>\n",
+       "      <td>960.645167</td>\n",
+       "      <td>231.143333</td>\n",
+       "      <td>11.465500</td>\n",
+       "      <td>13.476333</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 23:00:00</th>\n",
+       "      <td>5.343033</td>\n",
+       "      <td>257.641667</td>\n",
+       "      <td>5.366133</td>\n",
+       "      <td>5.240950</td>\n",
+       "      <td>281.474667</td>\n",
+       "      <td>72.718000</td>\n",
+       "      <td>961.312000</td>\n",
+       "      <td>68.300333</td>\n",
+       "      <td>11.219333</td>\n",
+       "      <td>13.331667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-22 00:00:00</th>\n",
+       "      <td>2.927500</td>\n",
+       "      <td>252.476667</td>\n",
+       "      <td>2.936183</td>\n",
+       "      <td>4.317467</td>\n",
+       "      <td>279.763983</td>\n",
+       "      <td>78.291667</td>\n",
+       "      <td>962.066667</td>\n",
+       "      <td>4.760350</td>\n",
+       "      <td>8.786167</td>\n",
+       "      <td>12.924167</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-22 01:00:00</th>\n",
+       "      <td>2.385250</td>\n",
+       "      <td>230.681667</td>\n",
+       "      <td>2.395933</td>\n",
+       "      <td>4.835133</td>\n",
+       "      <td>278.799167</td>\n",
+       "      <td>80.931667</td>\n",
+       "      <td>962.662333</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>6.896683</td>\n",
+       "      <td>12.847833</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-22 02:00:00</th>\n",
+       "      <td>2.688817</td>\n",
+       "      <td>234.703333</td>\n",
+       "      <td>2.693483</td>\n",
+       "      <td>3.079950</td>\n",
+       "      <td>278.030133</td>\n",
+       "      <td>83.405000</td>\n",
+       "      <td>963.125833</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>5.531783</td>\n",
+       "      <td>12.811333</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-22 03:00:00</th>\n",
+       "      <td>1.791483</td>\n",
+       "      <td>189.110000</td>\n",
+       "      <td>1.798300</td>\n",
+       "      <td>4.539783</td>\n",
+       "      <td>277.313650</td>\n",
+       "      <td>82.285000</td>\n",
+       "      <td>963.507333</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>4.243350</td>\n",
+       "      <td>12.785500</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-22 04:00:00</th>\n",
+       "      <td>1.543000</td>\n",
+       "      <td>207.200000</td>\n",
+       "      <td>1.545000</td>\n",
+       "      <td>3.276000</td>\n",
+       "      <td>276.976000</td>\n",
+       "      <td>82.200000</td>\n",
+       "      <td>963.750000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>3.598000</td>\n",
+       "      <td>12.770000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                         wspd        wdir  HorizontalWind  wdir_std  \\\n",
+       "datetime                                                              \n",
+       "2016-11-21 17:00:00  1.944483  240.593333        1.958867  6.601150   \n",
+       "2016-11-21 18:00:00  2.844367  251.378333        2.864533  6.527967   \n",
+       "2016-11-21 19:00:00  4.265933  251.836667        4.302117  7.274217   \n",
+       "2016-11-21 20:00:00  5.820167  255.511667        5.859383  6.527083   \n",
+       "2016-11-21 21:00:00  6.272000  251.678333        6.310000  6.242950   \n",
+       "2016-11-21 22:00:00  6.104433  254.995000        6.141233  6.223867   \n",
+       "2016-11-21 23:00:00  5.343033  257.641667        5.366133  5.240950   \n",
+       "2016-11-22 00:00:00  2.927500  252.476667        2.936183  4.317467   \n",
+       "2016-11-22 01:00:00  2.385250  230.681667        2.395933  4.835133   \n",
+       "2016-11-22 02:00:00  2.688817  234.703333        2.693483  3.079950   \n",
+       "2016-11-22 03:00:00  1.791483  189.110000        1.798300  4.539783   \n",
+       "2016-11-22 04:00:00  1.543000  207.200000        1.545000  3.276000   \n",
+       "\n",
+       "                              T         RH           P     SW_down       T10X  \\\n",
+       "datetime                                                                        \n",
+       "2016-11-21 17:00:00  280.433667  80.503333  959.679833  292.691667   8.233717   \n",
+       "2016-11-21 18:00:00  280.612000  83.845000  960.026000  235.665000   9.661167   \n",
+       "2016-11-21 19:00:00  282.391000  78.631667  960.055167  382.946667  10.185167   \n",
+       "2016-11-21 20:00:00  282.636833  77.340000  960.099833  342.491667  11.307333   \n",
+       "2016-11-21 21:00:00  282.516333  75.923333  960.322667  242.920500  11.641833   \n",
+       "2016-11-21 22:00:00  282.975000  70.868333  960.645167  231.143333  11.465500   \n",
+       "2016-11-21 23:00:00  281.474667  72.718000  961.312000   68.300333  11.219333   \n",
+       "2016-11-22 00:00:00  279.763983  78.291667  962.066667    4.760350   8.786167   \n",
+       "2016-11-22 01:00:00  278.799167  80.931667  962.662333    0.000000   6.896683   \n",
+       "2016-11-22 02:00:00  278.030133  83.405000  963.125833    0.000000   5.531783   \n",
+       "2016-11-22 03:00:00  277.313650  82.285000  963.507333    0.000000   4.243350   \n",
+       "2016-11-22 04:00:00  276.976000  82.200000  963.750000    0.000000   3.598000   \n",
+       "\n",
+       "                          p10X  \n",
+       "datetime                        \n",
+       "2016-11-21 17:00:00  13.519167  \n",
+       "2016-11-21 18:00:00  13.455833  \n",
+       "2016-11-21 19:00:00  13.479667  \n",
+       "2016-11-21 20:00:00  13.521000  \n",
+       "2016-11-21 21:00:00  13.466667  \n",
+       "2016-11-21 22:00:00  13.476333  \n",
+       "2016-11-21 23:00:00  13.331667  \n",
+       "2016-11-22 00:00:00  12.924167  \n",
+       "2016-11-22 01:00:00  12.847833  \n",
+       "2016-11-22 02:00:00  12.811333  \n",
+       "2016-11-22 03:00:00  12.785500  \n",
+       "2016-11-22 04:00:00  12.770000  "
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hr_mean = ps7.xs(3,level='height').resample('1h').mean()\n",
+    "hr_mean"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "T     281.474667\n",
+       "RH     72.718000\n",
+       "P     961.312000\n",
+       "Name: 2016-11-21 23:00:00, dtype: float64"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "testdata = hr_mean.loc['2016-11-21 23:00']\n",
+    "testdata[['T','RH','P']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "T, RH, p = testdata[['T','RH','P']]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### saturated vapor pressure\n",
+    "https://www.weather.gov/epz/wxcalc_vaporpressure gives $e_s$ = 10.97 mb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10.97058660841359"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e_s(T, model='Tetens') # Tetens' formula (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10.961379766199544"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e_s(T, model='Bolton') # Bolton (1980), Mon. Weather Rev., Vol 108"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### dewpoint temperature\n",
+    "https://www.weather.gov/epz/wxcalc_rh gives $T_d$ = 276.86 K (and wet-bulb temp = 279.22 K)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "276.872367630902"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "T_d(T, RH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### mixing ratio\n",
+    "https://www.weather.gov/epz/wxcalc_mixingratio gives $w_s$ = 7.17 g/kg (= 0.00717 kg/kg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.007180266769687286"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "w_s(T, p)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.007098324862722254"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# sanity check, assuming p >> e_s (Wallace & Hobbs, Eqn. 3.63)\n",
+    "eps * e_s(T) / p"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### virtual temperature\n",
+    "https://www.weather.gov/epz/wxcalc_virtualtemperature (using $T_d$ calculated from https://www.weather.gov/epz/wxcalc_rh) gives $T_v$ = 282.36"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "282.36317505413456"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "T_to_Tv(T, p=p, RH=RH)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "282.3604000240343"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Td = T_d(T, RH)\n",
+    "T_to_Tv(T, Td=Td, p=p)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,19 +13,33 @@ the `mmctools` repository and provide a basic analysis framework.
 - Read Wind Profiler radar data, and optionally, the scan properties using the
   `mmctools.measurements.radar.profiler()`
 - Process a directory of downloaded radar data, combining the data into a single
-  Pandas dataframe using `mmctools.dataloader.read_dir()`
+  Pandas dataframe using `mmctools.dataloaders.read_dir()`
 
 `examples/002-process_filelist.ipynb`
 
 - Process a list of downloaded radar data files, using the radar profiler
   reader, combining the data into a single Pandas dataframe using 
-  `mmctools.dataloader.read_files()`
+  `mmctools.dataloaders.read_files()`
 
 `examples/003-process_subdirs_quickplot.ipynb`
 
 - Process subdirectories of downloaded sodar data files, combining the data into
-  a single Pandas dataframe using `mmctools.dataloader.read_date_dirs()`
+  a single Pandas dataframe using `mmctools.dataloaders.read_date_dirs()`
 - Quick time-height plot using `mmctools.plotting.plot_timeheight()`
+
+`examples/004-process_met_data.ipynb`
+
+- **Complete example** demonstrating DAP file downloads (using `dap-py`), data
+  processing, and calculation of select atmospheric quantities.
+- Met mast data are processed using `mmctools.dataloaders.read_files()` in
+  conjunction with the `mmctools.measurements.metmast` submodule. The `metmast`
+  submodule provides `read_data()` for reading time series (e.g., measured by
+  sonic anemometers) at different heights within a single file.
+- In this case, the metmast data format is _NOT_ standard, so the fields are
+  defined by `metmast.RMYoung_05106`. This may be used as an example for other
+  similar met data.
+- Atmospheric calculations have been performed with different empirical models
+  implemented within `mmctools.helper_functions` wherever applicable. 
 
 ## advanced data processing 
 


### PR DESCRIPTION
This is a **complete example** copied over from `mmctools/tests/T_to_Tv_tests.ipynb`.
- Data download through `dap-py`
- Data read using `mmctools.measurements.metmast` with a custom column specification (because the met data have nonstandard names and units)
- Atmospheric quantities calculated using various `helper_functions`.